### PR TITLE
feat(base-app): add External Secrets support to base-app chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A seguir, uma lista dos charts disponíveis neste repositório.
 
 | Chart      | Versão | Descrição                                                                                             | Documentação         |
 |------------|--------|--------------------------------------------------------------------------------------------------------|----------------------|
-| base-app   | 1.0.0  | Um chart genérico e altamente configurável para deploy de qualquer aplicação, suportando Deployments, StatefulSets e Argo Rollouts. | [README](./charts/base-app/README.md) |
+| base-app   | 1.1.0  | Um chart genérico e altamente configurável para deploy de qualquer aplicação, suportando Deployments, StatefulSets, Argo Rollouts e External Secrets. | [README](./charts/base-app/README.md) |
 
 🤝 Contribuição
 

--- a/charts/base-app/Chart.yaml
+++ b/charts/base-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/base-app/README.md
+++ b/charts/base-app/README.md
@@ -109,3 +109,74 @@ Um "Headless Service" é útil para casos de uso stateful (como bancos de dados)
 | :-------------------- | :---------------------------------------------------------------------------------------------------- | :----- |
 | `autoscaling.enabled` | Se `true`, cria um `HorizontalPodAutoscaler` nativo do Kubernetes. É ignorado se `scaling.enabled` for `true`. | `false`  |
 | `scaling.enabled`     | Se `true`, cria um `ScaledObject` do KEDA para autoscaling avançado.                                     | `false`  |
+
+### Configurações de External Secrets (`externalSecrets`)
+
+| Parâmetro                 | Descrição                                                                           | Padrão      |
+| :------------------------ | :---------------------------------------------------------------------------------- | :---------- |
+| `enabled`                 | Se `true`, cria um recurso `ExternalSecret` para sincronizar secrets externos.      | `false`     |
+| `refreshInterval`         | Intervalo de sincronização do secret.                                               | `"60s"`     |
+| `secretStore.name`        | Nome do `SecretStore` ou `ClusterSecretStore` a ser usado.                         | `""`        |
+| `secretStore.kind`        | Tipo do secret store (`SecretStore` ou `ClusterSecretStore`).                      | `"SecretStore"` |
+| `dataFrom`                | Lista de configurações para importar todas as chaves de um caminho específico.      | `[]`        |
+| `data`                    | Lista de mapeamentos específicos de chaves do secret externo para o secret local.   | `[]`        |
+
+## 📚 Exemplos de Uso
+
+### Exemplo 1: Usando dataFrom (Importar todas as chaves)
+
+```yaml
+base-app:
+  nameOverride: "minha-app"
+  
+  externalSecrets:
+    enabled: true
+    secretStore:
+      name: "vault-secret-store"
+      kind: "SecretStore"
+    dataFrom:
+      - key: "secret/minha-app"
+```
+
+### Exemplo 2: Usando data (Mapeamento específico)
+
+```yaml
+base-app:
+  nameOverride: "minha-app"
+  
+  externalSecrets:
+    enabled: true
+    secretStore:
+      name: "vault-secret-store"
+      kind: "ClusterSecretStore"
+    data:
+      - secretKey: "database-password"
+        remoteRef:
+          key: "secret/database"
+          property: "password"
+      - secretKey: "api-token"
+        remoteRef:
+          key: "secret/api"
+          property: "token"
+```
+
+### Exemplo 3: Uso misto (dataFrom + data)
+
+```yaml
+base-app:
+  nameOverride: "minha-app"
+  
+  externalSecrets:
+    enabled: true
+    secretStore:
+      name: "vault-secret-store"
+    # Importa todas as chaves de configuração
+    dataFrom:
+      - key: "secret/minha-app/config"
+    # Adiciona chaves específicas
+    data:
+      - secretKey: "special-token"
+        remoteRef:
+          key: "secret/shared/tokens"
+          property: "service-token"
+```

--- a/charts/base-app/templates/externalsecret.yaml
+++ b/charts/base-app/templates/externalsecret.yaml
@@ -1,0 +1,67 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}
+  {{- include "base-app.labels" . | nindent 2 }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval | default "60s" }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: {{ .Values.externalSecrets.secretStore.kind | default "SecretStore" }}
+  target:
+    name: {{ .Values.externalSecrets.targetSecret.name | default (include "app.fullname" .) }}
+    {{- with .Values.externalSecrets.targetSecret.creationPolicy }}
+    creationPolicy: {{ . }}
+    {{- end }}
+    {{- with .Values.externalSecrets.targetSecret.deletionPolicy }}
+    deletionPolicy: {{ . }}
+    {{- end }}
+  
+  {{- if .Values.externalSecrets.dataFrom }}
+  {{/* Case 1: dataFrom - Load all keys from a path */}}
+  dataFrom:
+  {{- range .Values.externalSecrets.dataFrom }}
+    - extract:
+        key: {{ .key }}
+        {{- with .version }}
+        version: {{ . }}
+        {{- end }}
+        {{- with .property }}
+        property: {{ . }}
+        {{- end }}
+      {{- with .find }}
+      find:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .rewrite }}
+      rewrite:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+
+  {{- if .Values.externalSecrets.data }}
+  {{/* Case 2: data - Maps specific keys */}}
+  data:
+  {{- range .Values.externalSecrets.data }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .remoteRef.key }}
+        {{- with .remoteRef.property }}
+        property: {{ . }}
+        {{- end }}
+        {{- with .remoteRef.version }}
+        version: {{ . }}
+        {{- end }}
+      {{- with .sourceRef }}
+      sourceRef:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/base-app/values.yaml
+++ b/charts/base-app/values.yaml
@@ -189,8 +189,8 @@ autoscaling:
 
 scaling:
   enabled: false
-  pollingInterval: 30 # Intervalo de tempo em segundos para scaling
-  cooldownPeriod: 60  # Intervalo de tempo em segundos para downscaling a partir do processamento da última mensagem (ou ação do trigger em questão)
+  pollingInterval: 30 # Polling interval in seconds for scaling
+  cooldownPeriod: 60  # Cooldown period in seconds for downscaling after last message processing (or trigger action)
   minReplicas: 1
   maxReplicas: 10
   triggers:
@@ -283,6 +283,68 @@ secrets: {}
   #   key: sensitive_value
   # dockerconfigjson/image-pull: |
   #   .dockerconfigjson: {}
+
+##
+# External Secrets configuration
+##
+
+externalSecrets:
+  # externalSecrets.enabled -- Enable External Secrets
+  enabled: false
+  
+  # externalSecrets.refreshInterval -- How often to sync the secret
+  refreshInterval: "60s"
+  
+  # externalSecrets.annotations -- Additional annotations for the ExternalSecret
+  annotations: {}
+    # argocd.argoproj.io/sync-wave: "-10"
+  
+  # Secret store reference
+  secretStore:
+    # externalSecrets.secretStore.name -- Name of the SecretStore or ClusterSecretStore
+    name: ""
+    # externalSecrets.secretStore.kind -- Kind of secret store (SecretStore or ClusterSecretStore)
+    kind: "SecretStore"
+  
+  # Target secret configuration
+  targetSecret:
+    # externalSecrets.targetSecret.name -- Name of the target secret (defaults to app fullname)
+    name: ""
+    # externalSecrets.targetSecret.creationPolicy -- Creation policy for the target secret
+    creationPolicy: "Owner"
+    # externalSecrets.targetSecret.deletionPolicy -- Deletion policy for the target secret
+    deletionPolicy: "Retain"
+  
+  # Case 1: dataFrom - Load all keys from a path
+  # Use when you want to import all keys from a secret
+  dataFrom: []
+    # - key: "path/to/secret"
+    #   version: "latest"  # optional
+    #   property: "data"   # optional
+    #   find:              # optional
+    #     name:
+    #       regexp: ".*"
+    #   rewrite:           # optional
+    #     - regexp:
+    #         source: "(.*)_ENV"
+    #         target: "$1"
+  
+  # Case 2: data - Map specific keys
+  # Use when you want to map specific keys with different names
+  data: []
+    # - secretKey: "database-password"
+    #   remoteRef:
+    #     key: "database/credentials"
+    #     property: "password"
+    #     version: "latest"  # optional
+    #   sourceRef:           # optional
+    #     storeRef:
+    #       name: "vault-backend"
+    #       kind: "SecretStore"
+    # - secretKey: "api-token"
+    #   remoteRef:
+    #     key: "api/tokens"
+    #     property: "service-token"
 
 ##
 # Service account management


### PR DESCRIPTION
- Add externalsecret.yaml template with dataFrom and data support
- Support both SecretStore and ClusterSecretStore configurations
- Add comprehensive configuration options in values.yaml
- Include documentation with practical examples in README
- Update chart version to 1.1.0